### PR TITLE
fix setExpiration starting session prematurely

### DIFF
--- a/src/DI/MysqlSessionHandlerExtension.php
+++ b/src/DI/MysqlSessionHandlerExtension.php
@@ -22,7 +22,11 @@ class MysqlSessionHandlerExtension extends Nette\DI\CompilerExtension
 			->setClass('Pematon\Session\MysqlSessionHandler')
 			->addSetup('setTableName', [$config['tableName']]);
 
-		$builder->getDefinition('session')
-			->addSetup('setHandler', array($definition));
+
+		$sessionDefinition = $builder->getDefinition('session');
+		$sessionSetup = $sessionDefinition->getSetup();
+		# Prepend setHandler method to other possible setups (setExpiration) which would start session prematurely
+		array_unshift($sessionSetup, new Nette\DI\Statement('setHandler', array($definition)));
+		$sessionDefinition->setSetup($sessionSetup);
 	}
 }


### PR DESCRIPTION
If you configure expiration in Nette, it adds `setExpiration('14 days')` setup method to service initialization immediately after construct.
Combined with `autoStart: true|smart` this causes `setExpiration` to start session before this extensions `setHandler` is called.

This fix pushes `setHandler` setup method to be called right after construct, before any other options are to be applied.

Unfortunately, this fix is speculative, as I have had several problems setting up MySQL session storage. But this should not break anything and it makes sense to set handler before any other action is done on session service.

By the way, thanks for publishing this extension and taking time to go through this PR.
